### PR TITLE
Update README with feature details and bump package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you don't see a "Consent Management" option like the one below, please contac
 
 
   <!-- Add Segment's TrustArc Consent Wrapper -->
-  <script src="https://consent.trustarc.com/get?name=trustarc-segment-wrapper-v1.0.js"></script>
+  <script src="https://consent.trustarc.com/get?name=trustarc-segment-wrapper-v1.1.js"></script>
 
   <!--
     Add / Modify Segment Analytics Snippet
@@ -121,6 +121,8 @@ TrustArcWrapper.withTrustArc(analytics, { consentModelBasedOnConsentExperience: 
 ```
 
 ### Always Load Segment
+
+#### Feature available in version 1.1 and later
 
 If you are using Segment as a Required vendor, you can pass an additional parameter for Segment to load even on opt-in locations before there's any consent provided. This will allow Segment to load, while making sure that the visitor's consent choices are still propagated so that the destinations that are not mapped as required will not load. 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trustarc/trustarc-segment-wrapper",
-  "version": "1.0.6",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trustarc/trustarc-segment-wrapper",
-      "version": "1.0.6",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@segment/analytics-consent-tools": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustarc/trustarc-segment-wrapper",
-  "version": "1.0.6",
+  "version": "1.1.1",
   "description": "TrustArc wrapper for Segment",
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",


### PR DESCRIPTION
This pull request includes updates to the `README.md` file and `package.json` to reflect changes in the TrustArc Segment wrapper version. The most important changes include updating the script source URL, adding a new feature description, and updating the package version.

Documentation updates:

- Updated the TrustArc Segment wrapper script source URL to version 1.1.
- Added a new section describing a feature available in version 1.1 and later.

Version update:
- Updated the package version from 1.0.6 to 1.1.1.  I did the version bump to `1.1.0` to align with the CDN script version, npm package version and to follow semantic versioning since this is a minor feature addition and not just a patch.
