### PR TITLE
Adding flag considerUnprovisionedLocationsAsOptOut and version updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "compile-hero.disable-compile-files-on-did-save-code": true
-}

--- a/README.md
+++ b/README.md
@@ -133,21 +133,33 @@ TrustArcWrapper.withTrustArc(analytics, { alwaysLoadSegment: true })
   .load({ writeKey: '<MY_WRITE_KEY>' })
 ```
 
+### Consider Unprovisioned Locations as Opt-Out
+
+When you have locations that are not set in TrustArc's location settings (unprovisioned locations), by default the wrapper loads in opt-in mode. In such scenarios, it will remain in opt-in mode since unprovisioned locations will not provide a banner or option for users to make a consent decision. 
+
+If you want unprovisioned locations to load all destinations by default instead, you can use the `considerUnprovisionedLocationsAsOptOut` parameter to treat unprovisioned locations as opt-out.
+
+```ts
+TrustArcWrapper.withTrustArc(analytics, { considerUnprovisionedLocationsAsOptOut: true })
+  .load({ writeKey: '<MY_WRITE_KEY>' })
+```
+
+**Note:** Please consult with your privacy team before enabling this option to ensure it aligns with your consent requirements.
+
 ## Environments
 
 ### Build Artifacts
 
-- We build the following versions of the library
+The library is built in multiple formats to support different use cases:
 
 | Format | Description | Path |
 |--------|-------------|------|
-| `amd` (amd bundle) | When a AMD bundle is required | `trustarc_segment_wrapper.js` |
+| **UMD** | Universal Module Definition - works in browsers via `<script>` tag and module loaders | `dist/index.js` |
+| **CommonJS** | For Node.js and bundlers like webpack | `dist/cjs/src/index.js` |
+| **ESM** | ES Modules for modern bundlers and native browser imports | `dist/esm/src/index.js` |
 
 ### Browser Support
-- `amd` - Support back to IE11, but **do not** polyfill . See our docs on [supported browsers](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/supported-browsers).
 
-In order to get full ie11 support, you are expected to bring your own polyfills. e.g. adding the following to your script tag:
+This library supports all modern browsers. For supported browsers, see the [Segment Analytics.js documentation](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/supported-browsers).
 
-```html
-<script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.7.0/polyfill.min.js"></script>
-```
+**Note:** For legacy browser support, you may need to include polyfills for features like Promises, Object.assign, and Array methods depending on your target browsers.

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   testPathIgnorePatterns: [
     'src/lib/dist/',      // Exclude the tests directory from test execution
     '<rootDir>/src/tests/dist/',
+    '<rootDir>/dist/',    // Exclude compiled output from test execution
   ],
   globals: {
     "window": {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,14 +38,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -199,27 +199,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
-      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
-      "integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.8"
+        "@babel/types": "^7.28.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -468,15 +468,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.8.tgz",
-      "integrity": "sha512-iNKaX3ZebKIsCvJ+0jd6embf+Aulaa3vNBqZ41kM7iTWjx5qzWKXGHiJUW3+nTpQ18SG11hdF8OAzKrpXkb96Q==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.8",
-        "@babel/types": "^7.26.8"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -502,14 +502,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
-      "integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1696,9 +1696,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1780,6 +1780,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2151,6 +2164,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -2243,12 +2270,57 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
       "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2480,9 +2552,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2539,13 +2611,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -2578,7 +2652,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2604,6 +2677,30 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2612,6 +2709,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2666,6 +2776,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2681,11 +2803,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3652,9 +3800,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3871,6 +4019,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/merge-stream": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "LICENSE.txt",
+    "README.md"
+  ],
   "scripts": {
     "test": "jest --watch",
     "build": "npm run build:cjs && npm run build:esm && npm run build:umd",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,9 +46,7 @@ export interface TrustArcSettings {
     alwaysLoadSegment?: boolean,
 
     /**
-     * 
      * When this setting is set to true, locations that are not explicitly provisioned in TrustArc will be considered as opt-out.
-     * 
      */
     considerUnprovisionedLocationsAsOptOut?: boolean
 }
@@ -57,7 +55,7 @@ const shouldLoadWrapper = async () => {
     await resolveWhen(() => {
         const TrustArc = getTrustArcGlobal()
 
-        // Wrapper can load when TrustArc is done loading the the API is ready
+        // Wrapper can load when TrustArc is done loading and the API is ready
         return TrustArc !== undefined && TrustArc.cma !== undefined
     }, 500)
 };
@@ -76,9 +74,9 @@ const getConsentModel = (settings: TrustArcSettings) => {
     // When the location is unprovisioned, we consider it as opt-out if the setting is enabled.
     // If the setting is not enabled, we continue with the normal flow as unprovisioned locations 
     // will be treated as opt-in by default or use the configured defaults when consentModelBasedOnConsentExperience is used.
-    if(settings.considerUnprovisionedLocationsAsOptOut === true) {
+    if (settings.considerUnprovisionedLocationsAsOptOut === true) {
         const consentDecision = TrustArc.cma.callApi('getGDPRConsentDecision', window.location.hostname);
-        if(consentDecision.source === 'unprovisioned') {
+        if (consentDecision.source === 'unprovisioned') {
             settings.enableDebugLogging && log('getConsentModel triggered and returned opt-out based on unprovisioned location.');
             return 'opt-out';
         }
@@ -100,7 +98,7 @@ const getConsentModel = (settings: TrustArcSettings) => {
     // If no custom settings, use TrustArc's default behavior
     consentModel = coerceConsentModel(TrustArc.eu.bindMap.behaviorManager);
     settings.enableDebugLogging && log(`getConsentModel triggered and returned ${consentModel} based on behaviorManager.`);
-    return consentModel
+    return consentModel;
 };
 
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,6 @@
+/**
+ * Centralized logging function for the consent wrapper
+ */
+export const log = (...args: any[]): void => {
+    console.log('[consent wrapper debug]', ...args);
+};

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -50,8 +50,90 @@ describe("getCategories", () => {
             }
         };
 
-        const categories = testHelpers.getCategories();
+        const settings: TrustArcSettings = {};
+        const categories = testHelpers.getCategories(settings);
 
+        expect(categories).toEqual({ "ta-1": true, "ta-2": true, "ta-3": true, "ta-4": true });
+    });
+
+    test("should return opt-out categories when location is unprovisioned and considerUnprovisionedLocationsAsOptOut is true", () => {
+        // Mock the window.truste global variable with unprovisioned source
+        window.truste = {
+            eu: {
+                bindMap: {
+                    behaviorManager: "eu",
+                    categoryCount: 4,
+                    domain: "test.com"
+                }
+            },
+            cma: {
+                callApi: jest.fn().mockReturnValue({
+                    source: "unprovisioned",
+                    consentDecision: []
+                })
+            }
+        };
+
+        const settings: TrustArcSettings = {
+            considerUnprovisionedLocationsAsOptOut: true
+        };
+        const categories = testHelpers.getCategories(settings);
+
+        // In opt-out mode, all categories should be true by default
+        expect(categories).toEqual({ "ta-1": true, "ta-2": true, "ta-3": true, "ta-4": true });
+    });
+
+    test("should use normal flow when location is unprovisioned but considerUnprovisionedLocationsAsOptOut is false", () => {
+        // Mock the window.truste global variable with unprovisioned source
+        window.truste = {
+            eu: {
+                bindMap: {
+                    behaviorManager: "eu",
+                    categoryCount: 4,
+                    domain: "test.com"
+                }
+            },
+            cma: {
+                callApi: jest.fn().mockReturnValue({
+                    source: "unprovisioned",
+                    consentDecision: []
+                })
+            }
+        };
+
+        const settings: TrustArcSettings = {
+            considerUnprovisionedLocationsAsOptOut: false
+        };
+        const categories = testHelpers.getCategories(settings);
+
+        // Should follow normal opt-in behavior from behaviorManager
+        expect(categories).toEqual({ "ta-1": true, "ta-2": false, "ta-3": false, "ta-4": false });
+    });
+
+    test("should use normal flow when considerUnprovisionedLocationsAsOptOut is true but source is not unprovisioned", () => {
+        // Mock the window.truste global variable with provisioned source
+        window.truste = {
+            eu: {
+                bindMap: {
+                    behaviorManager: "eu",
+                    categoryCount: 4,
+                    domain: "test.com"
+                }
+            },
+            cma: {
+                callApi: jest.fn().mockReturnValue({
+                    source: "asserted",
+                    consentDecision: [1, 2, 3, 4]
+                })
+            }
+        };
+
+        const settings: TrustArcSettings = {
+            considerUnprovisionedLocationsAsOptOut: true
+        };
+        const categories = testHelpers.getCategories(settings);
+
+        // Should follow normal consent behavior
         expect(categories).toEqual({ "ta-1": true, "ta-2": true, "ta-3": true, "ta-4": true });
     });
 });
@@ -126,6 +208,71 @@ describe('shouldLoadSegment', () => {
         await expect(Promise.race([testHelpers.shouldLoadSegment(ctx, settings), timeoutPromise]))
             .rejects.toThrow('Timeout exceeded');
 
+    });
+
+    it('should load with opt-out consent model when location is unprovisioned and considerUnprovisionedLocationsAsOptOut is true', async () => {
+        const mockTrustArc = {
+            eu: {
+                bindMap: {
+                    behaviorManager: 'eu', // Consent model is opt-in
+                    categoryCount: 4,
+                    domain: 'test.com',
+                }
+            },
+            cma: {
+                callApi: jest.fn().mockReturnValue({
+                    source: 'unprovisioned',  // Unprovisioned location
+                    consentDecision: [],
+                }),
+            },
+        };
+
+        (getTrustArcGlobal as jest.Mock).mockReturnValue(mockTrustArc);
+
+        const ctx = { load: jest.fn() };
+        const settings: TrustArcSettings = {
+            considerUnprovisionedLocationsAsOptOut: true
+        };
+
+        await testHelpers.shouldLoadSegment(ctx, settings);
+
+        // Should load with opt-out model for unprovisioned locations
+        expect(ctx.load).toHaveBeenCalledWith({
+            consentModel: 'opt-out',
+        });
+    });
+
+    it('should load with opt-in consent model when location is unprovisioned but considerUnprovisionedLocationsAsOptOut is false', async () => {
+        const mockTrustArc = {
+            eu: {
+                bindMap: {
+                    behaviorManager: 'eu', // Consent model is opt-in
+                    categoryCount: 4,
+                    domain: 'test.com',
+                }
+            },
+            cma: {
+                callApi: jest.fn().mockReturnValue({
+                    source: 'unprovisioned',
+                    consentDecision: [],
+                }),
+            },
+        };
+
+        (getTrustArcGlobal as jest.Mock).mockReturnValue(mockTrustArc);
+
+        const ctx = { load: jest.fn() };
+        const settings: TrustArcSettings = {
+            considerUnprovisionedLocationsAsOptOut: false,
+            alwaysLoadSegment: true
+        };
+
+        await testHelpers.shouldLoadSegment(ctx, settings);
+
+        // Should follow normal opt-in behavior based on behaviorManager
+        expect(ctx.load).toHaveBeenCalledWith({
+            consentModel: 'opt-in',
+        });
     });
 });
 

--- a/src/tests/logger.test.ts
+++ b/src/tests/logger.test.ts
@@ -1,0 +1,51 @@
+import { log } from '../lib/logger';
+
+describe('logger', () => {
+    let consoleLogSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        // Mock console.log to prevent actual logging during tests
+        consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    afterEach(() => {
+        // Restore the original console.log after each test
+        consoleLogSpy.mockRestore();
+    });
+
+    test('should log with prefix "[consent wrapper debug]"', () => {
+        const message = 'Test message';
+        log(message);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith('[consent wrapper debug]', message);
+        expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('should log multiple arguments', () => {
+        const arg1 = 'First argument';
+        const arg2 = { key: 'value' };
+        const arg3 = 123;
+        
+        log(arg1, arg2, arg3);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith('[consent wrapper debug]', arg1, arg2, arg3);
+        expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('should handle no arguments', () => {
+        log();
+
+        expect(consoleLogSpy).toHaveBeenCalledWith('[consent wrapper debug]');
+        expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('should handle objects and arrays', () => {
+        const obj = { name: 'test', value: 42 };
+        const arr = [1, 2, 3];
+        
+        log(obj, arr);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith('[consent wrapper debug]', obj, arr);
+        expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/test.html
+++ b/test.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TrustArc Segment Wrapper Test</title>
+</head>
+<body>
+    <h1>TrustArc Segment Wrapper Test Page</h1>
+    <p>Open browser console to see debug output</p>
+
+    <!-- TrustArc Consent UI -->
+    <div id="consent_blackbar"></div>
+    <div id="teconsent"></div>
+
+    <!-- TrustArc Consent Script -->
+    <script async="async" type="text/javascript" crossorigin="" src='//consent.trustarc.com/notice?domain=felipebrito-demo.com&c=teconsent&js=nj&noticeType=bb&gtm=1&country=fr'></script>
+
+    <!-- Load the TrustArc Segment Wrapper (UMD build) -->
+    <script src="./dist/index.js"></script>
+
+    <!-- Segment Analytics Snippet -->
+    <script>
+        !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="YOUR_WRITE_KEY_HERE";;analytics.SNIPPET_VERSION="4.15.3";
+
+        // Use TrustArc wrapper with Segment
+        TrustArcWrapper.withTrustArc(analytics, {
+            enableDebugLogging: true,
+            alwaysLoadSegment: true,
+            disableConsentChangedEvent: false,
+            considerUnprovisionedLocationsAsOptOut: true
+        }).load('ZczNPC06XLlfQgnOleeFNFBvbJcVbG7v');
+
+        analytics.page();
+        }}();
+    </script>
+
+    <script>
+
+    </script>
+</body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,11 @@ module.exports = {
     output: {
         filename: 'index.js',
         path: path.resolve(__dirname, 'dist'),
-        libraryTarget: 'commonjs2', // Expose it in Node as a CommonJS module
+        library: {
+            name: 'TrustArcWrapper',
+            type: 'umd',
+        },
+        globalObject: 'this',
     },
     resolve: {
         extensions: ['.ts', '.js'], // Resolve these extensions


### PR DESCRIPTION
This pull request introduces a new feature that allows unprovisioned locations (those not explicitly set up in TrustArc) to be treated as opt-out for consent by setting a new option, `considerUnprovisionedLocationsAsOptOut`. It also adds a centralized debug logging utility, updates documentation, and improves test coverage for these changes. Additionally, the build output and configuration are updated for better compatibility and distribution.

**Feature: Unprovisioned Location Opt-Out**

- Added the `considerUnprovisionedLocationsAsOptOut` option to `TrustArcSettings`, which, when enabled, treats unprovisioned locations as opt-out for consent. This affects how consent models are determined and categories are returned. (F86e4eaeL43, [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L45-R113) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L118-R153)
- Updated the documentation in `README.md` to describe the new option and its privacy implications.

**Logging Improvements**

- Introduced a centralized `log` function in `src/lib/logger.ts` for consistent debug logging, and updated the codebase to use this logger instead of direct `console.log` calls. [[1]](diffhunk://#diff-73c4d73d75765ab186de329bbcb17bd1789967299b04fa88375c4a44a1797a27R1-R6) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R15-R16) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L118-R153)
- Added comprehensive tests for the new logger to ensure correct behavior and output.

**Testing Enhancements**

- Expanded test coverage for the new opt-out logic and its effects on category selection and consent model behavior in `src/tests/index.test.ts`. [[1]](diffhunk://#diff-920eff10ed5bfb6a81cbdfd320d28176eb9b5eccaf9b51ccd4dae8588a53ec30L53-R138) [[2]](diffhunk://#diff-920eff10ed5bfb6a81cbdfd320d28176eb9b5eccaf9b51ccd4dae8588a53ec30R212-R276)

**Build and Distribution Updates**

- Updated `webpack.config.js` to output the library as UMD for broader compatibility, and set the global object for universal use.
- Updated `package.json` to explicitly include distribution files, source, and documentation in published packages.

**Other Changes**

- Removed unused `.vscode/settings.json` file.

These changes collectively improve the flexibility, maintainability, and clarity of the TrustArc wrapper, especially in handling edge cases around unprovisioned locations and debugging.